### PR TITLE
Update outline.js

### DIFF
--- a/lib/outline.js
+++ b/lib/outline.js
@@ -78,7 +78,8 @@ function generateWarningsAboutMissingDestinations (layer, pdfDoc) {
   if (dests) {
     const validDestinationTargets = dests.entries().map(([key, _]) => key.value())
     for (const item of layer) {
-      if (!validDestinationTargets.includes('/' + item.destination)) {
+      let destination = decodeURIComponent(item.destination.replace(/\#25/g, '%'))
+		  if (!validDestinationTargets.includes('/' + destination)) {
         console.warn(`Unable to find destination ${item.destination} while generating PDF outline! \
 This likely happened because an anchor link contained an umlaut (https://bugs.chromium.org/p/chromium/issues/detail?id=985254).`)
       }


### PR DESCRIPTION
@ggrossetie I have noticed that even though my anchor destination was correct, I was getting the initial error.  This is the effect of the fact that the generateWarningsAboutMissingDestinations function must to decode the target of the anchors that are now encoded.  See the values below:
------------
Item destination known-issues#253A#253A#253A                                                                                                             Valid destination targets:  [ '/known-issues:::', '/legacy-devices:::' ]   -----------
If you can, please review my proposal. It fixed all these false positive errors in my case. Thanks!