### PR TITLE
test: add regression test for ordered list numbering across pages

### DIFF
--- a/test/fixtures/ordered-list-numbering-across-pages.adoc
+++ b/test/fixtures/ordered-list-numbering-across-pages.adoc
@@ -1,0 +1,63 @@
+= Ordered List Numbering Across Pages
+
+== Section
+
+. item-1-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-2-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-3-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-4-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-5-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-6-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-7-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-8-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-9-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-10-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-11-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-12-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-13-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-14-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-15-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-16-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-17-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-18-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-19-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-20-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-21-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-22-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-23-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-24-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-25-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-26-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-27-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-28-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-29-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.
+
+. item-30-marker filler text to give the list item some height so the list spans multiple pages when repeated many times over.

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -439,6 +439,26 @@ describe('PDF converter', () => {
       }
     })
 
+    it('should keep sequential numbering when an ordered list spans multiple pages', async () => {
+      const outputFile = outputPath('ordered-list-numbering-across-pages.pdf')
+      const pdfDoc = await convert(
+        fixturesPath('ordered-list-numbering-across-pages.adoc'),
+        outputFile,
+      )
+      assert.strictEqual(
+        pdfDoc.getPages().length,
+        2,
+        'expected the ordered list to span exactly 2 pages',
+      )
+      const text = helper.extractText(outputFile)
+      for (let i = 1; i <= 30; i++) {
+        assert.ok(
+          text.includes(`${i}. item-${i}-marker`),
+          `expected item ${i} to be numbered "${i}." instead of restarting the counter`,
+        )
+      }
+    })
+
     it('should keep a consistent number of rows per page when a table with images spans multiple pages', async () => {
       const outputFile = outputPath('table-with-images-spanning-pages.pdf')
       const pdfDoc = await convert(


### PR DESCRIPTION
Adds a regression test covering #708
An ordered list used to restart numbering at 1 on each new page instead of continuing sequentially. This was fixed by the Paged.js to Vivliostyle migration; the test guards against a future regression by asserting a 30-item list spans exactly 2 pages and every item keeps its correct sequential number across the page break.
