### PR TITLE
test: add regression test for TOC dot leader with manual toc::[] placement

### DIFF
--- a/test/fixtures/toc-macro-dot-leader.adoc
+++ b/test/fixtures/toc-macro-dot-leader.adoc
@@ -1,0 +1,22 @@
+= Demo
+:toc:
+:toc-placement!:
+
+[preface]
+== Preface
+
+Preface text.
+
+toc::[]
+
+<<<
+
+== Section One
+
+Content.
+
+<<<
+
+== Section Two
+
+Content.

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -459,6 +459,25 @@ describe('PDF converter', () => {
       }
     })
 
+    it('should render the TOC dot leader when the TOC is placed manually with the toc::[] macro', async () => {
+      const outputFile = outputPath('toc-macro-dot-leader.pdf')
+      await converter.convert(
+        { path: fixturesPath('toc-macro-dot-leader.adoc') },
+        { to_file: outputFile },
+        false,
+      )
+      const lines = helper
+        .extractText(outputFile)
+        .split('\n')
+        .map((line) => line.replace(/\s+/g, ''))
+      for (const title of ['Preface', 'SectionOne', 'SectionTwo']) {
+        assert.ok(
+          lines.some((line) => new RegExp(`^${title}\\.{10,}\\d+$`).test(line)),
+          `expected a dot leader between "${title}" and its page number in the TOC`,
+        )
+      }
+    })
+
     it('should keep a consistent number of rows per page when a table with images spans multiple pages', async () => {
       const outputFile = outputPath('table-with-images-spanning-pages.pdf')
       const pdfDoc = await convert(


### PR DESCRIPTION
Adds a regression test covering #655
The dot leader between each TOC entry and its page number wasn't rendered when the TOC was manually positioned with the toc::[] macro instead of the default auto placement. This was fixed by the Paged.js to Vivliostyle migration; the test guards against a future regression by asserting each entry in a manually-placed TOC (preface + toc::[] macro) still has a dotted leader between its title and page number in the extracted PDF text.
