### PR TITLE
feat: set backend attribute to pdf

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -67,11 +67,15 @@ export class PdfOptions extends Options {
   }
 
   _buildConvertOptions(extraAttrs = []) {
-    return super._buildConvertOptions([
-      'env-web-pdf',
-      'env=web-pdf',
+    const built = super._buildConvertOptions([
+      'converter=web-pdf',
+      'pdf-generator=browser',
       ...extraAttrs,
     ])
+    if (!built.options.backend) {
+      built.options.backend = 'pdf'
+    }
+    return built
   }
 }
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -45,6 +45,7 @@ export function registerTemplateConverter(templates) {
       this.backendTraits = {
         basebackend: 'html',
         outfilesuffix: '.pdf',
+        filetype: 'pdf',
         htmlsyntax: 'html',
         supportsTemplates: true,
       }
@@ -65,7 +66,7 @@ export function registerTemplateConverter(templates) {
     }
   }
 
-  ConverterFactory.register(new TemplateConverter(), ['html5'])
+  ConverterFactory.register(new TemplateConverter(), ['pdf'])
 }
 
 export async function convert(
@@ -102,7 +103,9 @@ export async function convert(
       outputFile = options.to_file
     }
   }
-  const instanceOptions = Object.assign({}, options, { to_file: tempFile })
+  const instanceOptions = Object.assign({ backend: 'pdf' }, options, {
+    to_file: tempFile,
+  })
   let doc
   let timer
 

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -3,9 +3,33 @@ import { describe, it } from 'node:test'
 
 import { convert } from '@asciidoctor/core'
 import { PdfInvoker, PdfOptions } from '../lib/cli.js'
+import { registerTemplateConverter } from '../lib/converter.js'
+import { templates } from '../lib/document/document-converter.js'
+
+registerTemplateConverter(templates)
 
 describe('CLI', () => {
-  it('should set the env attributes', async () => {
+  it('should default the backend to pdf', () => {
+    const options = new PdfOptions().parse([
+      'node',
+      'asciidoctor-pdf',
+      'doc.adoc',
+    ])
+    const pdfInvoker = new PdfInvoker(options)
+    assert.strictEqual(pdfInvoker.options.options.backend, 'pdf')
+  })
+  it('should not override an explicit backend', () => {
+    const options = new PdfOptions().parse([
+      'node',
+      'asciidoctor-pdf',
+      'doc.adoc',
+      '-b',
+      'html5',
+    ])
+    const pdfInvoker = new PdfInvoker(options)
+    assert.strictEqual(pdfInvoker.options.options.backend, 'html5')
+  })
+  it('should set the converter attributes', async () => {
     const options = new PdfOptions().parse([
       'node',
       'asciidoctor-pdf',
@@ -13,40 +37,39 @@ describe('CLI', () => {
     ])
     const pdfInvoker = new PdfInvoker(options)
     const attributes = pdfInvoker.options.options.attributes
-    assert.ok(attributes.includes('env-web-pdf'))
-    assert.ok(attributes.includes('env=web-pdf'))
+    assert.ok(attributes.includes('converter=web-pdf'))
+    assert.ok(attributes.includes('pdf-generator=browser'))
     const html = await convert(
-      '{env}',
+      '{converter} {pdf-generator}',
       Object.assign({}, pdfInvoker.options.options, { standalone: false }),
     )
     assert.strictEqual(
       html,
       `<div class="paragraph">
-<p>web-pdf</p>
+<p>web-pdf browser</p>
 </div>`,
     )
   })
-  it('should override the default env attributes', async () => {
+  it('should override the default converter attributes', async () => {
     const options = new PdfOptions().parse([
       'node',
       'asciidoctor-pdf',
       'doc.adoc',
       '-a',
-      'env=pdf',
+      'converter=custom-pdf',
     ])
     const pdfInvoker = new PdfInvoker(options)
     const attributes = pdfInvoker.options.options.attributes
-    assert.ok(attributes.includes('env-web-pdf'))
-    assert.ok(attributes.includes('env=web-pdf'))
-    assert.ok(attributes.includes('env=pdf'))
+    assert.ok(attributes.includes('converter=web-pdf'))
+    assert.ok(attributes.includes('converter=custom-pdf'))
     const html = await convert(
-      '{env}',
+      '{converter}',
       Object.assign({}, pdfInvoker.options.options, { standalone: false }),
     )
     assert.strictEqual(
       html,
       `<div class="paragraph">
-<p>pdf</p>
+<p>custom-pdf</p>
 </div>`,
     )
   })

--- a/test/converter_test.js
+++ b/test/converter_test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { load } from '@asciidoctor/core'
+import { registerTemplateConverter } from '../lib/converter.js'
+import { templates } from '../lib/document/document-converter.js'
+
+describe('registerTemplateConverter', () => {
+  it('should register the converter for the pdf backend', async () => {
+    registerTemplateConverter(templates)
+    const doc = await load('= Test\n\ncontent', { backend: 'pdf' })
+    assert.strictEqual(doc.getAttribute('backend'), 'pdf')
+    assert.strictEqual(doc.getAttribute('basebackend'), 'html')
+    assert.strictEqual(doc.getAttribute('filetype'), 'pdf')
+    assert.strictEqual(doc.getAttribute('outfilesuffix'), '.pdf')
+  })
+})

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -11,10 +11,14 @@ converter.registerTemplateConverter(templates)
 const __dirname = import.meta.dirname
 const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 
+function loadPdf(source, opts = {}) {
+  return load(source, { ...opts, backend: 'pdf' })
+}
+
 describe('Default converter', () => {
   describe('Language', () => {
     it('should have a default language', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 
 == Section`)
       const root = parse(await templates.document(doc))
@@ -22,7 +26,7 @@ describe('Default converter', () => {
     })
 
     it('respect the document lang attribute', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :lang: de
 
 == Section`)
@@ -31,7 +35,7 @@ describe('Default converter', () => {
     })
 
     it('respect the document nolang attribute', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :nolang:
 
 == Section`)
@@ -45,7 +49,7 @@ describe('Default converter', () => {
 
   describe('Page title', () => {
     it('should include a title page if title-page attribute is defined', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 Guillaume Grossetie
 :title-page:
 
@@ -58,7 +62,7 @@ Guillaume Grossetie
     })
 
     it('should include a title page if doctype is book', async () => {
-      const doc = await load(
+      const doc = await loadPdf(
         `= Title
 Guillaume Grossetie
 
@@ -73,7 +77,7 @@ Guillaume Grossetie
     })
 
     it('should not include a title page', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 Guillaume Grossetie
 
 == Section`)
@@ -82,7 +86,7 @@ Guillaume Grossetie
     })
 
     it('should not include a title page if the document title is empty', async () => {
-      const doc = await load('Hello world!', {
+      const doc = await loadPdf('Hello world!', {
         attributes: { 'title-page': '' },
       })
       const root = parse(await doc.convert({ standalone: true }))
@@ -90,7 +94,7 @@ Guillaume Grossetie
     })
 
     it('should not include a document title if the document title is empty', async () => {
-      const doc = await load('Hello world!')
+      const doc = await loadPdf('Hello world!')
       const root = parse(await doc.convert({ standalone: true }))
       assert.strictEqual(
         root.querySelectorAll('.title-document > h1').length,
@@ -100,7 +104,7 @@ Guillaume Grossetie
   })
 
   it('should replace the default stylesheet with a custom stylesheet', async () => {
-    const doc = await load('[.greetings]#Hello world#', {
+    const doc = await loadPdf('[.greetings]#Hello world#', {
       attributes: { stylesheet: fixturesPath('custom.css') },
     })
     const root = parse(await doc.convert({ standalone: true }))
@@ -117,7 +121,7 @@ Guillaume Grossetie
   })
 
   it('should load multiple stylesheets', async () => {
-    const doc = await load('Hello world', {
+    const doc = await loadPdf('Hello world', {
       attributes: {
         stylesheet: `${fixturesPath('variable.css')}, ,${fixturesPath('theme.css')},`,
       },
@@ -142,7 +146,7 @@ Guillaume Grossetie
   })
 
   it('should resolve the stylesheet when using a relative path', async () => {
-    const doc = await load('[.greetings]#Hello world#', {
+    const doc = await loadPdf('[.greetings]#Hello world#', {
       attributes: {
         stylesheet: ospath.join(
           '@asciidoctor',
@@ -177,7 +181,7 @@ Guillaume Grossetie
 
   describe('Stem', () => {
     it('should include MathJax CHTML stylesheet when stem is set', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :stem:
 
 == Section`)
@@ -186,7 +190,7 @@ Guillaume Grossetie
     })
 
     it('should not include MathJax CHTML stylesheet when stem is not set', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :stem!:
 
 == Section`)
@@ -195,7 +199,7 @@ Guillaume Grossetie
     })
 
     it('should not include MathJax CHTML stylesheet when stem is not present', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 
 == Section`)
       const root = parse(await templates.document(doc))
@@ -203,7 +207,7 @@ Guillaume Grossetie
     })
 
     it('should add equation numbers when eqnums equals AMS', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :stem: latexmath
 :eqnums: AMS
 
@@ -217,7 +221,7 @@ Guillaume Grossetie
     })
 
     it('should add equation numbers when eqnums is present', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :stem: latexmath
 :eqnums:
 
@@ -231,7 +235,7 @@ Guillaume Grossetie
     })
 
     it('should add equation numbers when eqnums equals all', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :stem: latexmath
 :eqnums: all
 
@@ -247,7 +251,7 @@ Guillaume Grossetie
 
   describe('Admonition', () => {
     it('should use an emoji shortcode as admonition icon', async () => {
-      const doc = await load(`= Title
+      const doc = await loadPdf(`= Title
 :tip-caption: :bulb:
 
 [TIP]
@@ -263,7 +267,7 @@ It's possible to use emojis as admonition.`)
   describe('Inline icon', () => {
     describe('FontAwesome SVG icons set', () => {
       it('should enable SVG icon when icons attribute is equals to font (user experience)', async () => {
-        const doc = await load(
+        const doc = await loadPdf(
           `= Title
 :icons: font
 
@@ -278,7 +282,7 @@ icon:address-book[]`,
         )
       })
       it('should render a solid FontAwesome SVG icon (default)', async () => {
-        const doc = await load(`:icontype: svg
+        const doc = await loadPdf(`:icontype: svg
 
 icon:address-book[]`)
         const root = parse(await doc.convert())
@@ -289,7 +293,7 @@ icon:address-book[]`)
         )
       })
       it('should render a regular FontAwesome SVG icon (default)', async () => {
-        const doc = await load(`:icontype: svg
+        const doc = await loadPdf(`:icontype: svg
 
 icon:address-book[set=far]`)
         const root = parse(await doc.convert())
@@ -300,7 +304,7 @@ icon:address-book[set=far]`)
         )
       })
       it('should render a brand FontAwesome SVG icon (default)', async () => {
-        const doc = await load(`:icontype: svg
+        const doc = await loadPdf(`:icontype: svg
 
 icon:chrome@fab[]`)
         const root = parse(await doc.convert())
@@ -315,7 +319,7 @@ icon:chrome@fab[]`)
 
   describe('Table Of Contents', () => {
     it('should add a toc when toc is set', async () => {
-      const doc = await load(
+      const doc = await loadPdf(
         `= Title
 :toc:
 
@@ -334,7 +338,7 @@ icon:chrome@fab[]`)
     })
 
     it("should not add a toc when there's no section", async () => {
-      const doc = await load(
+      const doc = await loadPdf(
         `= Title
 :toc:
 
@@ -349,7 +353,7 @@ Just a preamble.`,
     })
 
     it('should not add a toc in the header when toc placement is macro', async () => {
-      const doc = await load(
+      const doc = await loadPdf(
         `= Title
 :toc: macro
 


### PR DESCRIPTION
Register the template converter for the `pdf` backend instead of `html5`, so `{backend}` reflects the actual output format. Also add `filetype=pdf` (backend trait) and `converter=web-pdf` / `pdf-generator=browser` (default document attributes) so AsciiDoc authors can reliably detect this converter, replacing the `env-web-pdf` / `env=web-pdf` attributes which misused the `env` attribute for this purpose.

This is a breaking change: documents using `ifdef::backend-html5[]` or `{env-web-pdf}` need to switch to `ifdef::backend-pdf[]` / `{converter}`.

Closes #129