### PR TITLE
fix: wrap long unbroken words in table cells instead of overflowing the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migrated the release process to a manually triggered GitHub Actions workflow with npm trusted publishing ([#722](https://github.com/ggrossetie/asciidoctor-web-pdf/pull/722))
 - The release workflow now rolls this changelog into a dated release section and uses it as the GitHub release notes
 - README now links to the published documentation site instead of duplicating the table of contents
+
+### Fixed
+
+- Long unbroken words (e.g. a fully-qualified class name) in a table cell no longer overflow past the page edge; they now wrap ([#164](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/164))

--- a/css/document.css
+++ b/css/document.css
@@ -156,6 +156,7 @@ table.frame-all {
 table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td {
   line-height: 1.25rem;
   font-size: 0.9rem;
+  overflow-wrap: anywhere;
 }
 
 table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock {

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -624,7 +624,7 @@ describe('PDF converter', () => {
 
   describe('Known issues (bucket D backlog triage)', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/164
-    it.skip('should wrap a long unbroken word instead of letting it overflow the page', async () => {
+    it('should wrap a long unbroken word instead of letting it overflow the page', async () => {
       const outputFile = outputPath('table-cell-long-word.pdf')
       const pdfDoc = await convert(
         fixturesPath('table-cell-long-word.adoc'),


### PR DESCRIPTION
Table cells only used `overflow-wrap: break-word`, which does not affect the auto table-layout algorithm's intrinsic width calculation — so a long unbroken word (e.g. a fully-qualified class name) still forced the column wider than the page and ran off the edge.

Switching to `overflow-wrap: anywhere` lets the browser factor the possible break into the column's minimum content width, so it wraps instead of overflowing.

Un-skips the regression test added for #164, which now passes.

Fixes #164