### PR TITLE
fix: three bucket C quick wins (sidebar break, generator meta, subtitle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - New documentation site built with Antora ([#731](https://github.com/ggrossetie/asciidoctor-web-pdf/pull/731))
 - Binaries are now built as Node.js Single Executable Applications (SEA), replacing `pkg`, adding native macOS and Linux arm64 support ([#723](https://github.com/ggrossetie/asciidoctor-web-pdf/pull/723))
+- A `generator` meta tag with the current version is now included in the document `<head>`, useful for debugging ([#300](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/300))
 
 ### Changed
 
@@ -23,3 +24,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Long unbroken words (e.g. a fully-qualified class name) in a table cell no longer overflow past the page edge; they now wrap ([#164](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/164))
+- Sidebar and example blocks no longer split across a page break ([#374](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/374))
+- The document subtitle is now rendered distinctly from the main title on the title page, instead of being merged into the same heading ([#699](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/699))

--- a/css/document.css
+++ b/css/document.css
@@ -120,6 +120,13 @@ h6 {
   margin: 0;
 }
 
+h1 .subtitle {
+  display: block;
+  font-size: 0.55em;
+  font-weight: 400;
+  margin-top: 0.4rem;
+}
+
 h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 {
   color: #333;
   font-family: 'Noto Serif', serif;
@@ -185,6 +192,14 @@ tr {
 }
 
 .listingblock {
+  break-inside: avoid;
+}
+
+.sidebarblock {
+  break-inside: avoid;
+}
+
+.exampleblock {
   break-inside: avoid;
 }
 

--- a/lib/document/document-converter.js
+++ b/lib/document/document-converter.js
@@ -19,6 +19,7 @@ import {
   faQuestionCircle,
   fas,
 } from '@fortawesome/free-solid-svg-icons'
+import pkg from '../../package.json' with { type: 'json' }
 import { processStem } from './stem.js'
 import './syntax-highlighter.js'
 
@@ -139,6 +140,7 @@ ${content}
 <head>
 <title>${node.getDocumentTitle({ sanitize: true, use_fallback: true })}</title>
 <meta charset="UTF-8">
+<meta name="generator" content="Asciidoctor Web PDF ${pkg.version}">
 ${this.fontAwesomeStyle(node)}
 ${this.styles(node)}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -595,15 +597,19 @@ ${faDom.css()}
   titlePage(node) {
     if (node.getDocumentTitle()) {
       const doc = node.getDocument()
+      const doctitle = node.getDocumentTitle({ partition: true })
+      const title = doctitle.hasSubtitle()
+        ? `${doctitle.getMain()}<small class="subtitle">${doctitle.getSubtitle()}</small>`
+        : doctitle.getMain()
       if (this.hasTitlePage(doc)) {
         const author = doc.getAuthor()
         return `<div id="cover" class="title-page front-matter">
-  <h1>${node.getDocumentTitle()}</h1>
+  <h1>${title}</h1>
   ${author ? `<h2>${author}</h2>` : ''}
 </div>`
       }
       return `<div class="title-document">
-  <h1>${node.getDocumentTitle()}</h1>
+  <h1>${title}</h1>
 </div>`
     }
     return ''

--- a/test/fixtures/sidebar-avoid-page-break.adoc
+++ b/test/fixtures/sidebar-avoid-page-break.adoc
@@ -1,0 +1,61 @@
+= Sidebar Break Test
+
+Filler paragraph number 1 to push content down toward the bottom of the first page.
+
+Filler paragraph number 2 to push content down toward the bottom of the first page.
+
+Filler paragraph number 3 to push content down toward the bottom of the first page.
+
+Filler paragraph number 4 to push content down toward the bottom of the first page.
+
+Filler paragraph number 5 to push content down toward the bottom of the first page.
+
+Filler paragraph number 6 to push content down toward the bottom of the first page.
+
+Filler paragraph number 7 to push content down toward the bottom of the first page.
+
+Filler paragraph number 8 to push content down toward the bottom of the first page.
+
+Filler paragraph number 9 to push content down toward the bottom of the first page.
+
+Filler paragraph number 10 to push content down toward the bottom of the first page.
+
+Filler paragraph number 11 to push content down toward the bottom of the first page.
+
+Filler paragraph number 12 to push content down toward the bottom of the first page.
+
+Filler paragraph number 13 to push content down toward the bottom of the first page.
+
+Filler paragraph number 14 to push content down toward the bottom of the first page.
+
+Filler paragraph number 15 to push content down toward the bottom of the first page.
+
+Filler paragraph number 16 to push content down toward the bottom of the first page.
+
+Filler paragraph number 17 to push content down toward the bottom of the first page.
+
+Filler paragraph number 18 to push content down toward the bottom of the first page.
+
+****
+START-SIDEBAR-MARKER
+
+Sidebar filler line 1 that adds enough height to force a split if break-inside is not honored.
+
+Sidebar filler line 2 that adds enough height to force a split if break-inside is not honored.
+
+Sidebar filler line 3 that adds enough height to force a split if break-inside is not honored.
+
+Sidebar filler line 4 that adds enough height to force a split if break-inside is not honored.
+
+Sidebar filler line 5 that adds enough height to force a split if break-inside is not honored.
+
+Sidebar filler line 6 that adds enough height to force a split if break-inside is not honored.
+
+Sidebar filler line 7 that adds enough height to force a split if break-inside is not honored.
+
+Sidebar filler line 8 that adds enough height to force a split if break-inside is not honored.
+
+END-SIDEBAR-MARKER
+****
+
+AFTER-SIDEBAR-MARKER

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -582,6 +582,27 @@ describe('PDF converter', () => {
         `expected the same horizontal position for every occurrence, got: ${distinctPositions.join(', ')}`,
       )
     })
+
+    // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/374
+    it('should not split a sidebar block across a page break', async () => {
+      const outputFile = outputPath('sidebar-avoid-page-break.pdf')
+      await converter.convert(
+        { path: fixturesPath('sidebar-avoid-page-break.adoc') },
+        { to_file: outputFile },
+        false,
+      )
+      const pages = helper.extractText(outputFile).split('\f')
+      const pageOf = (marker) =>
+        pages.findIndex((page) => page.includes(marker))
+      const startPage = pageOf('START-SIDEBAR-MARKER')
+      const endPage = pageOf('END-SIDEBAR-MARKER')
+      assert.ok(startPage >= 0 && endPage >= 0)
+      assert.strictEqual(
+        startPage,
+        endPage,
+        `expected the sidebar block to stay on a single page, got start on page ${startPage} and end on page ${endPage}`,
+      )
+    })
   })
 
   describe('PDF outline destinations', () => {

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -5,6 +5,7 @@ import { convert, load } from '@asciidoctor/core'
 import { parse } from 'node-html-parser'
 import * as converter from '../lib/converter.js'
 import { templates } from '../lib/document/document-converter.js'
+import pkg from '../package.json' with { type: 'json' }
 
 converter.registerTemplateConverter(templates)
 
@@ -45,6 +46,20 @@ describe('Default converter', () => {
         undefined,
       )
     })
+  })
+
+  // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/300
+  it('should include a generator meta tag with the current version', async () => {
+    const doc = await loadPdf(`= Title
+
+== Section`)
+    const root = parse(await templates.document(doc))
+    assert.strictEqual(
+      root
+        .querySelector('head > meta[name="generator"]')
+        ?.getAttribute('content'),
+      `Asciidoctor Web PDF ${pkg.version}`,
+    )
   })
 
   describe('Page title', () => {
@@ -99,6 +114,43 @@ Guillaume Grossetie
       assert.strictEqual(
         root.querySelectorAll('.title-document > h1').length,
         0,
+      )
+    })
+
+    // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/699
+    it('should render the subtitle distinctly from the main title', async () => {
+      const doc = await loadPdf('= Main Title: A Subtitle Marker')
+      const root = parse(await doc.convert({ standalone: true }))
+      const h1 = root.querySelector('.title-document > h1')
+      assert.strictEqual(
+        h1.querySelector('.subtitle')?.textContent,
+        'A Subtitle Marker',
+      )
+      assert.strictEqual(
+        h1.textContent,
+        'Main TitleA Subtitle Marker',
+        'expected the main title text to exclude the subtitle separator',
+      )
+    })
+
+    it('should render the subtitle distinctly on the cover title page too', async () => {
+      const doc = await loadPdf(
+        '= Main Title: A Subtitle Marker\nGuillaume Grossetie\n:title-page:',
+      )
+      const root = parse(await doc.convert({ standalone: true }))
+      const h1 = root.querySelector('.title-page > h1')
+      assert.strictEqual(
+        h1.querySelector('.subtitle')?.textContent,
+        'A Subtitle Marker',
+      )
+    })
+
+    it('should not render an empty subtitle element when there is no subtitle', async () => {
+      const doc = await loadPdf('= Main Title')
+      const root = parse(await doc.convert({ standalone: true }))
+      assert.strictEqual(
+        root.querySelector('.title-document > h1')?.querySelector('.subtitle'),
+        null,
       )
     })
   })


### PR DESCRIPTION
- Sidebar and example blocks now get `break-inside: avoid`, matching table/listing blocks, so they no longer split across a page break (#374).
- The document HTML now includes a `<meta name="generator">` tag with the current version, useful for debugging (#300).
- `titlePage()` now partitions the document title so the subtitle renders as its own `<small class="subtitle">` instead of being merged into the main `<h1>` text, on both the cover and the plain title page (#699).

Each fix has a regression test: an end-to-end one for #374 in `test/pdf_test.js` (page-splitting requires full PDF rendering), fast unit tests for #300 and #699 in `test/templates_test.js` (HTML-only, no Puppeteer needed).
