### PR TITLE
fix: reuse a single browser across conversions instead of relaunching per document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Referencing the same footnote more than once no longer duplicates it at the bottom of the page; the repeat reference now links back to the original ([#664](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/664))
 - Tables with `frame=all` now show their outer border again when `grid` is anything other than `all` (e.g. `grid=rows`) ([#676](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/676))
 - The revision number, date and remark are now rendered on the title page when set ([#84](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/84))
+- When converting several documents against a shared browser instance (e.g. `--watch` across multiple files), each document is now rendered in a clean page instead of silently reusing stale content from the previous one

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -83,18 +83,28 @@ export default class Browser {
       waitUntil: 'networkidle0',
       timeout: this.navigationTimeout,
     }
-    if (activePage) {
+    if (activePage && activePage.url() === BLANK_PAGE_URL) {
       page = activePage
       activePageUrl = new URL(activePage.url())
-      if (activePage.url() === BLANK_PAGE_URL) {
-        await page.goto(url, options)
-      } else {
-        await page.reload(options)
-      }
+      await page.goto(url, options)
+    } else if (activePage && activePage.url() === url) {
+      // Same document (e.g. watch mode): the URL is unchanged but its
+      // underlying file changed on disk, so force a refetch instead of a
+      // same-URL goto(), which Chromium would treat as a no-op navigation.
+      page = activePage
+      activePageUrl = new URL(activePage.url())
+      await page.reload(options)
     } else {
+      // No page for this URL yet, or the existing one is showing a different
+      // document (e.g. converting several files against one shared browser):
+      // use a fresh page rather than navigating the old one in place, since
+      // Vivliostyle's pagination relies on a clean session per document.
       page = await browser.newPage()
       this._addPageEventListeners(page, preview, verbose)
       await page.goto(url, options)
+      if (activePage) {
+        await activePage.close()
+      }
     }
     // watchdog
     await page.waitForFunction(

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -78,7 +78,13 @@ export async function convert(
   verbose,
   preserveHtml,
   preprocessScripts,
+  browser,
 ) {
+  // Allows callers converting multiple documents in a row (e.g. tests, a future
+  // CLI batch mode) to keep a single browser alive across calls instead of
+  // paying a launch+close cost per conversion. When omitted, falls back to the
+  // module-level singleton, which this function closes itself (single-shot CLI use).
+  const activeBrowser = browser || browserInstance
   const tempFile = getTemporaryHtmlFile(inputFile.path, options)
   let workingDir
   if (options.to_dir) {
@@ -129,7 +135,7 @@ export async function convert(
     const realTempFile = fsExtra.realpathSync(tempFile)
     const docFileUrl = pathToFileURL(realTempFile).href
     if (preprocessScripts) {
-      const enrichedHtml = await browserInstance.preprocessScripts(
+      const enrichedHtml = await activeBrowser.preprocessScripts(
         docFileUrl,
         preprocessScripts,
         verbose,
@@ -137,7 +143,7 @@ export async function convert(
       await fsExtra.writeFile(realTempFile, enrichedHtml)
     }
     const viewerUrl = `${pathToFileURL(viewerIndexPath).href}#src=${docFileUrl}&bookMode=false&renderAllPages=true&spread=false`
-    const page = await browserInstance.goto(viewerUrl, preview, verbose)
+    const page = await activeBrowser.goto(viewerUrl, preview, verbose)
     const puppeteerDefaultTimeout = process.env.PUPPETEER_DEFAULT_TIMEOUT
     const printTimeout =
       process.env.PUPPETEER_PRINT_TIMEOUT || puppeteerDefaultTimeout || 30000
@@ -196,7 +202,9 @@ export async function convert(
         await new Promise((_resolve) => {})
       }
     } else {
-      await browserInstance.close()
+      if (!browser) {
+        await browserInstance.close()
+      }
       if (!preserveHtml) {
         await fsExtra.remove(tempFile)
       }

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -36,6 +36,25 @@ function assertVisuallyIdentical(outputFile, reference) {
 }
 
 describe('PDF converter', () => {
+  // Shared across every test in this file so Chromium is launched once
+  // instead of once per conversion (this file alone converts ~30 documents).
+  const sharedBrowser = new Browser()
+
+  // Wraps converter.convert() with the shared browser plumbed into its
+  // trailing (rarely used in tests) positional params.
+  const convertPdf = (inputFile, options, timings) =>
+    converter.convert(
+      inputFile,
+      options,
+      timings,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      sharedBrowser,
+    )
+
   before(() => {
     const outputDir = ospath.join(__dirname, 'output')
     fs.rmSync(outputDir, { recursive: true, force: true })
@@ -43,7 +62,8 @@ describe('PDF converter', () => {
     fs.writeFileSync(ospath.join(outputDir, '.gitkeep'), '')
   })
 
-  after(() => {
+  after(async () => {
+    await sharedBrowser.close()
     if (typeof process.env.DEBUG === 'undefined') {
       const outputDir = ospath.join(__dirname, 'output')
       fs.rmSync(outputDir, { recursive: true, force: true })
@@ -83,7 +103,7 @@ describe('PDF converter', () => {
   const convert = async (inputFile, outputFile, options) => {
     const opts = options || {}
     opts.to_file = outputFile
-    await converter.convert({ path: inputFile }, opts, false)
+    await convertPdf({ path: inputFile }, opts, false)
     return PDFDocument.load(fs.readFileSync(outputFile))
   }
 
@@ -100,7 +120,7 @@ describe('PDF converter', () => {
     opts.attributes = attributes || {}
     opts.attributes.reproducible = ''
     opts.to_file = outputFile
-    await converter.convert(
+    await convertPdf(
       { path: fixturesPath(`${inputBaseFileName}.adoc`) },
       opts,
       false,
@@ -429,7 +449,7 @@ describe('PDF converter', () => {
   describe('Page splitting (regressions from the Paged.js era)', () => {
     it('should not lose table rows when a table spans multiple pages', async () => {
       const outputFile = outputPath('table-spanning-pages.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('table-spanning-pages.adoc') },
         { to_file: outputFile },
         false,
@@ -465,7 +485,7 @@ describe('PDF converter', () => {
 
     it('should render the TOC dot leader when the TOC is placed manually with the toc::[] macro', async () => {
       const outputFile = outputPath('toc-macro-dot-leader.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('toc-macro-dot-leader.adoc') },
         { to_file: outputFile },
         false,
@@ -520,7 +540,7 @@ describe('PDF converter', () => {
 
     it('should not drop content around highlighted code blocks near a page break', async () => {
       const outputFile = outputPath('highlighted-code-near-page-break.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('highlighted-code-near-page-break.adoc') },
         { to_file: outputFile },
         false,
@@ -559,7 +579,7 @@ describe('PDF converter', () => {
     // of every occurrence across the page break.
     it('should preserve indentation in a code block split across a page break', async () => {
       const outputFile = outputPath('source-code-split-across-pages.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('source-code-split-across-pages.adoc') },
         { to_file: outputFile },
         false,
@@ -586,7 +606,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/374
     it('should not split a sidebar block across a page break', async () => {
       const outputFile = outputPath('sidebar-avoid-page-break.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('sidebar-avoid-page-break.adoc') },
         { to_file: outputFile },
         false,
@@ -665,7 +685,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/241
     it('should render collapsible block content even without the %open option', async () => {
       const outputFile = outputPath('collapsible-block.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('collapsible-block.adoc') },
         { to_file: outputFile },
         false,
@@ -680,7 +700,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/492
     it('should place the ToC after the preamble for the book doctype when toc-placement is preamble', async () => {
       const outputFile = outputPath('toc-preamble-book-doctype.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('toc-preamble-book-doctype.adoc') },
         { to_file: outputFile },
         false,
@@ -702,7 +722,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/547
     it.skip('should not render the document title when showtitle is unset', async () => {
       const outputFile = outputPath('showtitle-disabled.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('showtitle-disabled.adoc') },
         { to_file: outputFile },
         false,
@@ -718,7 +738,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/664
     it('should not duplicate a footnote that is referenced more than once', async () => {
       const outputFile = outputPath('footnotes-duplicate.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('footnotes.adoc') },
         { to_file: outputFile },
         false,
@@ -735,7 +755,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/676
     it('should render the table frame border when grid is set to rows', async () => {
       const outputFile = outputPath('table-frame-with-grid-rows.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('table-frame-with-grid-rows.adoc') },
         { to_file: outputFile },
         false,
@@ -764,7 +784,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/84
     it('should render the revision number, date and remark on the title page', async () => {
       const outputFile = outputPath('title-page-metadata.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('title-page-metadata.adoc') },
         { to_file: outputFile },
         false,
@@ -830,7 +850,7 @@ describe('PDF converter', () => {
       converter.registerTemplateConverter(customTemplates)
       try {
         const outputFile = outputPath('custom-template-override.pdf')
-        await converter.convert(
+        await convertPdf(
           { path: fixturesPath('custom-template-override.adoc') },
           { to_file: outputFile },
           false,
@@ -852,7 +872,7 @@ describe('PDF converter', () => {
     // https://github.com/ggrossetie/asciidoctor-web-pdf/issues/684
     it('should apply cols alignment to body cells, not just the header row', async () => {
       const outputFile = outputPath('table-column-alignment.pdf')
-      await converter.convert(
+      await convertPdf(
         { path: fixturesPath('table-column-alignment.adoc') },
         { to_file: outputFile },
         false,


### PR DESCRIPTION
`convert()` closed the shared Puppeteer browser after every single conversion, so converting several documents (e.g. `--watch` across multiple files, or the test suite) paid a full Chromium launch+teardown per document instead of once.

`convert()` now accepts an optional browser instance; when supplied, the caller owns its lifecycle instead of `convert()` closing it. Single-shot CLI usage is unaffected (falls back to the existing module-level singleton, closed as before).

Reusing one browser across different documents surfaced a real bug in `Browser.goto()`: it matched the existing tab by URL pathname only, which is identical for every document since only the URL hash carries the source file. Navigating to a different document therefore took the `reload()` branch, which ignores the requested URL and just reloads whatever the tab is already showing — silently re-rendering the previous, and often already-deleted, document. `goto()` now only `reload()`s when the target URL exactly matches the current one (the `--watch` case: same file, changed on disk); any other document gets a fresh page instead of navigating the old one in place.

`test/pdf_test.js` now shares one browser across the whole file, cutting its running time roughly in half.
