### PR TITLE
ci: cache the Docker image build with GitHub Actions cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
     - name: Build container image
-      run: make packageLocalDocker
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        tags: asciidoctor-web-pdf:latest
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: Smoke test
       run: make testDocker
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
     - name: Build container image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         tags: asciidoctor-web-pdf:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migrated the release process to a manually triggered GitHub Actions workflow with npm trusted publishing ([#722](https://github.com/ggrossetie/asciidoctor-web-pdf/pull/722))
 - The release workflow now rolls this changelog into a dated release section and uses it as the GitHub release notes
 - README now links to the published documentation site instead of duplicating the table of contents
+- The CI Docker image build now uses a GitHub Actions cache, speeding up the `check` job
 
 ### Fixed
 


### PR DESCRIPTION
The `check` job's Docker build (`make packageLocalDocker`) rebuilds both image stages from scratch on every CI run, including `apt-get install chromium` (~300MB) twice and `npm ci`, which is the bulk of its ~1m42s runtime.

Replaces the plain `docker build` invocation with `docker/build-push-action`, using GitHub Actions cache (`type=gha`, `mode=max`) so unchanged layers are reused across runs instead of rebuilt. Local `make packageLocalDocker` is untouched.
