### PR TITLE
fix: always use CJS require for MathJax component loading, fixing stem on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tables with `frame=all` now show their outer border again when `grid` is anything other than `all` (e.g. `grid=rows`) ([#676](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/676))
 - The revision number, date and remark are now rendered on the title page when set ([#84](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/84))
 - When converting several documents against a shared browser instance (e.g. `--watch` across multiple files), each document is now rendered in a clean page instead of silently reusing stale content from the previous one
+- `:stem:` no longer fails to load MathJax on Windows with `Only URLs with a scheme in: file, data, and node are supported by the default ESM loader`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,9 @@ Assets copied alongside the binary (all resolved relative to `path.dirname(proce
 
 In SEA mode, the viewer index path is `path.join(path.dirname(process.execPath), 'viewer', 'index.html')`.
 
-**SEA-specific MathJax wiring** (`lib/document/stem.js`): before the first `MathJax.init()` call, two overrides are applied to the loader config:
-- `config.loader.paths.mathjax` → `assets/mathjax/` (esbuild sets `__dirname` to the binary dir, making `node-main.js` compute the wrong root)
-- `config.loader.require` → CJS `require` (the default `eval("(file) => import(file)")` uses dynamic ESM import which does not work in a SEA/CJS-only context)
+**MathJax loader wiring** (`lib/document/stem.js`): before the first `MathJax.init()` call, overrides are applied to the loader config:
+- `config.loader.require` → CJS `require`, always, on every platform. The default `eval("(file) => import(file)")` uses dynamic ESM `import()`, which does not work in a SEA/CJS-only context, and also fails on Windows for plain drive-letter paths (`C:/...`) since Node's ESM loader requires a `file://` URL there.
+- `config.loader.paths.mathjax` → `assets/mathjax/`, SEA-only (esbuild sets `__dirname` to the binary dir, making `node-main.js` compute the wrong root)
 
 ## Development
 

--- a/lib/document/stem.js
+++ b/lib/document/stem.js
@@ -37,11 +37,16 @@ async function getMathJax(tags) {
         'assets',
         'mathjax',
       )
-      // node-main.js sets loader.require to eval("(file) => import(file)") which
-      // uses dynamic ESM import. SEA binaries run in CJS-only mode, so import()
-      // of external files does not work. Replace with a plain CJS require instead.
-      MathJaxModule.config.loader.require = require
     }
+    // node-main.js sets loader.require to eval("(file) => import(file)"), which
+    // dynamically imports component files by path. On Windows, Node's ESM loader
+    // rejects plain drive-letter paths (e.g. "C:/...") because they aren't valid
+    // file:// URLs, so the default loader throws "Only URLs with a scheme in:
+    // file, data, and node are supported". Use a plain CJS require instead, which
+    // accepts OS paths natively on every platform (and is required in SEA mode
+    // anyway, since SEA binaries run in CJS-only mode where import() of external
+    // files does not work).
+    MathJaxModule.config.loader.require = require
     instances.set(
       tags,
       MathJaxModule.init({

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import ospath from 'node:path'
 import { describe, it } from 'node:test'
 import { convert, load } from '@asciidoctor/core'
+import MathJaxModule from 'mathjax'
 import { parse } from 'node-html-parser'
 import * as converter from '../lib/converter.js'
 import { templates } from '../lib/document/document-converter.js'
@@ -239,6 +240,25 @@ Guillaume Grossetie
 == Section`)
       const root = parse(await templates.document(doc))
       assert.ok(root.querySelector('style#MJX-CHTML-styles'))
+    })
+
+    it('loads MathJax components with a CJS require instead of the default dynamic ESM import', async () => {
+      // The default `loader.require` (`eval("(file) => import(file)")`) breaks on
+      // Windows: resolved component paths are plain drive-letter paths (e.g.
+      // "C:/..."), and Node's ESM loader rejects those as an invalid "c:" URL
+      // scheme. stem.js overrides `loader.require` with a plain CJS require,
+      // which accepts OS paths natively on every platform.
+      const doc = await loadPdf(`= Title
+:stem:
+
+== Section`)
+      await templates.document(doc)
+      const loaderRequire = MathJaxModule.config.loader.require
+      assert.strictEqual(typeof loaderRequire, 'function')
+      assert.ok(
+        !loaderRequire.toString().includes('import('),
+        'expected MathJax loader.require to be a CJS require, not the default dynamic import()',
+      )
     })
 
     it('should not include MathJax CHTML stylesheet when stem is not set', async () => {


### PR DESCRIPTION
MathJax's Node loader defaults `config.loader.require` to `eval("(file) => import(file)")`, i.e. dynamic ESM `import()`. On Windows, when it resolves a component path such as `C:/.../mathjax/input/tex.js`, Node's ESM resolver treats `C:` as a URL scheme and rejects it (it requires a `file://` URL), throwing `Only URLs with a scheme in: file, data, and node are supported by the default ESM loader`. `MathJax.init()` then never resolves, so `mj.startup` is `undefined` in `processStem`.

The codebase already worked around this exact bug for SEA binaries by swapping in plain CJS `require`, which accepts OS paths natively on every platform, but the override was scoped to `isSea` only. A normal npm install running on Windows (not a SEA binary) still hit the buggy default `import()` path.

This change applies the CJS `require` override unconditionally, in `lib/document/stem.js`.
