### PR TITLE
fix: avoid runtime package.json read for --version in SEA binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `:stem:` no longer fails to load MathJax on Windows with `Only URLs with a scheme in: file, data, and node are supported by the default ESM loader`
 - Binaries no longer fail with `Cannot find module '@puppeteer/browsers'` (or, for documents using `:stem:` with Greek/Cyrillic/etc. characters, `Cannot find module '@mathjax/mathjax-newcm-font/chtml.js'`) when run outside of a development checkout; the build now smoke-tests the binary from an isolated directory to catch this class of bug
+- Binaries no longer fail with `ENOENT: no such file or directory, open '.../package.json'` when run with `--version`; the smoke test now also runs `--version` to catch this class of bug
 
 ## [1.0.0] - 2026-08-15
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,10 @@
 import { createRequire } from 'node:module'
 import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import {
+  getVersion as getAsciidoctorJsVersion,
+  getCoreVersion,
+} from 'asciidoctor'
 import { Invoker, Options } from 'asciidoctor/cli'
 import chokidar from 'chokidar'
 import pkg from '../package.json' with { type: 'json' }
@@ -81,7 +85,15 @@ export class PdfOptions extends Options {
 
 export class PdfInvoker extends Invoker {
   version() {
-    return `Asciidoctor Web PDF ${pkg.version} [https://github.com/ggrossetie/asciidoctor-web-pdf]\n${super.version()}`
+    // Not delegating to super.version(): it reads asciidoctor's own package.json
+    // via readFileSync(join(import.meta.dirname, '..', 'package.json')), which
+    // esbuild rewrites to __dirname — the SEA binary's directory at runtime, not
+    // the asciidoctor package's directory — so the file lookup fails. getVersion()
+    // and getCoreVersion() report the same information without a runtime fs read.
+    return `Asciidoctor Web PDF ${pkg.version} [https://github.com/ggrossetie/asciidoctor-web-pdf]
+Asciidoctor.js ${getAsciidoctorJsVersion()} (Asciidoctor ${getCoreVersion()}) [https://asciidoctor.org]
+Runtime Environment (node ${process.version} on ${process.platform})
+CLI version ${getAsciidoctorJsVersion()}`
   }
 
   async invoke() {

--- a/tasks/prepare-binaries.js
+++ b/tasks/prepare-binaries.js
@@ -260,6 +260,8 @@ function smokeTest() {
     if (!isWindows) {
       fs.chmodSync(binaryPath, 0o755)
     }
+    execFileSync(binaryPath, ['--version'], { stdio: 'inherit' })
+
     const inputDoc = path.join(
       smokeTestDir,
       'examples',


### PR DESCRIPTION
`PdfInvoker.version()` delegated to asciidoctor's own `version()`, which reads its `package.json` via a path built from `import.meta.dirname`. esbuild rewrites that to `__dirname`, which in a SEA binary resolves to the binary's own directory rather than the asciidoctor package's, so the read fails with `ENOENT: no such file or directory, open '.../package.json'` when running `--version`.

The version string is now built from `getVersion()`/`getCoreVersion()` instead, which are backed by a build-time-inlined JSON import and need no runtime file read.

Also adds `--version` to the build's smoke test so this class of bug is caught going forward.
