### PR TITLE
fix: use MathJax's promise-based API for stem conversion to support on-demand-loaded font variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `:stem:` no longer fails with `MathJax retry -- an asynchronous action is required` for expressions needing a font variant not loaded upfront, e.g. `\mathscr` ([#748](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/748))
+
 ## [1.0.1] - 2026-08-17
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,8 @@ MathJax component JS files (`input/tex`, `input/asciimath`, `output/chtml` and t
 
 `output/chtml` also `require()`s the `@mathjax/mathjax-newcm-font` component server-side for glyph metrics (`chtml.js`, plus per-script files under `chtml/dynamic/` such as `greek.js`/`cyrillic.js`, loaded on demand) — separate from the woff2 files below, which are only for Chromium's CSS. In SEA mode these live in `assets/mathjax-newcm-font/`.
 
+Because those per-variant glyph files are loaded on demand and that load is inherently asynchronous, `stem.js` converts expressions with the promise-based `tex2chtmlPromise()`/`asciimath2chtmlPromise()` API, not the synchronous `tex2chtml()`/`asciimath2chtml()`. The synchronous API throws `MathJax retry -- an asynchronous action is required` as soon as an expression needs a variant not already loaded (e.g. `\mathscr`, which needs the "script" variant) — this reproduces on every platform, not just Windows/SEA.
+
 ### Syntax highlighting
 
 `lib/document/syntax-highlighter.js` registers a server-side highlight.js adapter with Asciidoctor. Source blocks are highlighted during conversion (spans already in the HTML when Vivliostyle processes it) and the chosen theme CSS (default: `github`) is inlined in `<head>`. Theme files are read from `node_modules/highlight.js/styles/` at runtime, or from `assets/highlight/styles/` in SEA mode.

--- a/lib/document/stem.js
+++ b/lib/document/stem.js
@@ -25,6 +25,21 @@ function getFontURL() {
   return pathToFileURL(ospath.join(fontPkgPath, 'chtml', 'woff2')).href
 }
 
+// Sequential, not Promise.all: MathJax's TeX input jax keeps shared mutable
+// state across compiles (e.g. equation-number counters for the `tags` option),
+// so concurrent compiles could interleave and produce nondeterministic numbering.
+async function replaceAsync(str, regex, asyncFn) {
+  const matches = Array.from(str.matchAll(regex))
+  if (matches.length === 0) return str
+  let result = ''
+  let lastIndex = 0
+  for (const m of matches) {
+    result += str.slice(lastIndex, m.index) + (await asyncFn(...m))
+    lastIndex = m.index + m[0].length
+  }
+  return result + str.slice(lastIndex)
+}
+
 const instances = new Map()
 
 async function getMathJax(tags) {
@@ -86,31 +101,44 @@ export async function processStem(html, node) {
   let result = html
 
   // Display math inside .stemblock divs (AsciiMath \$...\$ or TeX \[...\])
-  result = result.replace(
+  result = await replaceAsync(
+    result,
     /(<div class="stemblock">[\s\S]*?<div class="content">)([\s\S]*?)(<\/div>[\s\S]*?<\/div>)/g,
-    (_, before, content, after) => {
-      content = content.replace(/\\\$([\s\S]*?)\\\$/g, (__, f) => {
-        const node = mj.asciimath2chtml(f.trim(), { display: true })
-        adaptor.setAttribute(node, 'display', 'true')
-        return adaptor.outerHTML(node)
-      })
-      content = content.replace(/\\\[([\s\S]*?)\\\]/g, (__, f) => {
-        const node = mj.tex2chtml(f.trim(), { display: true })
-        adaptor.setAttribute(node, 'display', 'true')
-        return adaptor.outerHTML(node)
-      })
+    async (_, before, content, after) => {
+      content = await replaceAsync(
+        content,
+        /\\\$([\s\S]*?)\\\$/g,
+        async (__, f) => {
+          const node = await mj.asciimath2chtmlPromise(f.trim(), {
+            display: true,
+          })
+          adaptor.setAttribute(node, 'display', 'true')
+          return adaptor.outerHTML(node)
+        },
+      )
+      content = await replaceAsync(
+        content,
+        /\\\[([\s\S]*?)\\\]/g,
+        async (__, f) => {
+          const node = await mj.tex2chtmlPromise(f.trim(), { display: true })
+          adaptor.setAttribute(node, 'display', 'true')
+          return adaptor.outerHTML(node)
+        },
+      )
       return before + content + after
     },
   )
 
   // Inline TeX: \(...\)
-  result = result.replace(/\\\(([\s\S]*?)\\\)/g, (_, f) =>
-    adaptor.outerHTML(mj.tex2chtml(f.trim(), { display: false })),
+  result = await replaceAsync(result, /\\\(([\s\S]*?)\\\)/g, async (_, f) =>
+    adaptor.outerHTML(await mj.tex2chtmlPromise(f.trim(), { display: false })),
   )
 
   // Inline AsciiMath: \$...\$
-  result = result.replace(/\\\$([\s\S]*?)\\\$/g, (_, f) =>
-    adaptor.outerHTML(mj.asciimath2chtml(f.trim(), { display: false })),
+  result = await replaceAsync(result, /\\\$([\s\S]*?)\\\$/g, async (_, f) =>
+    adaptor.outerHTML(
+      await mj.asciimath2chtmlPromise(f.trim(), { display: false }),
+    ),
   )
 
   // Inject CHTML stylesheet after all expressions are rendered so all

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -319,6 +319,22 @@ Guillaume Grossetie
       assert.ok(root.querySelector('style#MJX-CHTML-styles'))
       assert.ok(root.querySelector('[id^="mjx-eqn:"]'))
     })
+
+    it('should render a stem expression that needs an on-demand-loaded font variant', async () => {
+      // \mathscr needs the "script" font variant, whose glyph metrics are
+      // loaded on demand from @mathjax/mathjax-newcm-font's chtml/dynamic/
+      // component. That load is inherently asynchronous, so it can't
+      // complete inside MathJax's synchronous tex2chtml()/asciimath2chtml()
+      // API and throws "MathJax retry -- an asynchronous action is
+      // required" (#748). stem.js must use the promise-based
+      // tex2chtmlPromise()/asciimath2chtmlPromise() API instead.
+      const doc = await loadPdf(`= Title
+:stem: latexmath
+
+stem:[\\mathscr{C}]`)
+      const root = parse(await templates.document(doc))
+      assert.ok(root.querySelector('mjx-container'))
+    })
   })
 
   describe('Admonition', () => {


### PR DESCRIPTION
Some MathJax font variants (e.g. the "script" variant used by `\mathscr`) aren't loaded upfront — their glyph metrics are `require()`'d on demand from `@mathjax/mathjax-newcm-font`'s `chtml/dynamic/` component. That load is inherently asynchronous, but `stem.js` was calling MathJax's synchronous `tex2chtml()`/`asciimath2chtml()` API, so any expression needing such a variant threw `MathJax retry -- an asynchronous action is required` — on every platform, not just Windows/SEA as originally suspected.

Switches `processStem` to the promise-based `tex2chtmlPromise()`/`asciimath2chtmlPromise()` API. Conversions stay sequential (not `Promise.all`) since MathJax's TeX input jax keeps shared mutable state across compiles (e.g. equation-number counters for `eqnums`), so concurrent compiles could interleave and produce nondeterministic numbering.

Fixes #748
