### PR TITLE
fix: resolve all PDF named destinations to explicit ones to respect the spec's name-length limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `:stem:` no longer fails with `MathJax retry -- an asynchronous action is required` for expressions needing a font variant not loaded upfront, e.g. `\mathscr` ([#748](https://github.com/ggrossetie/asciidoctor-web-pdf/issues/748))
+- Internal links and bookmarks no longer trigger PDF validator warnings such as `Warning: name token is longer than what the specification says it can be`; Vivliostyle's long encoded destination names are now resolved to explicit destinations and the oversized name dictionary is dropped from the output
 
 ## [1.0.1] - 2026-08-17
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -14,6 +14,7 @@ import { PDFDocument } from 'pdf-lib'
 import Browser from './browser.js'
 import { addMetadata } from './metadata.js'
 import { addOutline } from './outline.js'
+import { sanitizeNamedDestinations } from './pdf-destinations.js'
 
 const require = createRequire(import.meta.url)
 const mkdirs = promisify(fsExtra.mkdirs)
@@ -211,6 +212,7 @@ export async function convert(inputFile, options, config = {}) {
       let pdf = await page.pdf(pdfOptions)
       let pdfDoc = await PDFDocument.load(pdf)
       pdfDoc = await addOutline(pdfDoc, doc, docFileUrl)
+      sanitizeNamedDestinations(pdfDoc)
       pdfDoc = await addMetadata(pdfDoc, doc)
       pdf = await pdfDoc.save()
       if (outputToStdout) {

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -1,5 +1,6 @@
 import { decode as htmlEntitiesDecode } from 'html-entities'
 import { PDFDict, PDFHexString, PDFName, PDFNumber } from 'pdf-lib'
+import { resolveNamedDestination } from './pdf-destinations.js'
 
 const SanitizeXMLRx = /<[^>]+>/g
 
@@ -65,16 +66,9 @@ function buildPdfObjectsForOutline(layer, context, dests) {
 
     // Resolve named destination to explicit page-based destination to avoid
     // long PDF name tokens (Vivliostyle uses full encoded URLs as dest names)
-    let dest
-    if (dests) {
-      const destEntry = dests.get(PDFName.of(item.destination))
-      if (destEntry) {
-        dest = context.lookup(destEntry) || destEntry
-      }
-    }
-    if (!dest) {
-      dest = PDFName.of(item.destination)
-    }
+    const dest =
+      resolveNamedDestination(dests, context, PDFName.of(item.destination)) ||
+      PDFName.of(item.destination)
 
     const pdfObject = new Map([
       [PDFName.of('Title'), PDFHexString.fromText(item.title)],

--- a/lib/pdf-destinations.js
+++ b/lib/pdf-destinations.js
@@ -1,0 +1,130 @@
+import { PDFDict, PDFName, PDFRef } from 'pdf-lib'
+
+const SubtypeName = PDFName.of('Subtype')
+const LinkName = PDFName.of('Link')
+const DestName = PDFName.of('Dest')
+const DestsName = PDFName.of('Dests')
+
+/**
+ * Vivliostyle encodes named destinations as "viv-id-<full-source-URL>#<id>",
+ * with every non-alphanumeric/underscore character percent-escaped as
+ * ":XXXX" (4-digit hex). Since the source URL is a `file://` path, the
+ * resulting PDF name token routinely exceeds several hundred bytes - well
+ * past the 127-byte limit for name objects in the PDF spec (ISO 32000-1,
+ * 7.3.5), which trips up strict validators (e.g. "name token is longer than
+ * what the specification says it can be").
+ *
+ * This module resolves every reference to such a named destination - PDF
+ * outline (bookmark) entries and in-page link annotations alike - to the
+ * explicit destination array it points to, then drops the `/Dests` name
+ * dictionary that held the oversized names in the first place.
+ */
+
+/**
+ * Look up a named destination and return the explicit destination it points
+ * to (a `[page Ref, /XYZ|/Fit|..., ...]` array, typically), resolving one
+ * level of indirection if the dictionary stores it as a reference.
+ *
+ * @param {PDFDict|undefined} dests - The document's `/Dests` name dictionary
+ *   (`context.lookup(catalog.get(PDFName.of('Dests')))`), or undefined if
+ *   the document has none.
+ * @param {import('pdf-lib').PDFContext} context
+ * @param {PDFName} name - The named destination to resolve.
+ * @returns {import('pdf-lib').PDFObject|undefined} The explicit destination,
+ *   or undefined if `name` isn't a key of `dests`.
+ */
+export function resolveNamedDestination(dests, context, name) {
+  if (!dests) {
+    return undefined
+  }
+  const entry = dests.get(name)
+  if (!entry) {
+    return undefined
+  }
+  return context.lookup(entry) || entry
+}
+
+function getDests(pdfDoc) {
+  return pdfDoc.context.lookup(pdfDoc.catalog.get(DestsName))
+}
+
+/**
+ * Replace every link annotation's named `/Dest` (a `PDFName`) with the
+ * explicit destination it resolves to, across every page. Annotations whose
+ * `/Dest` is already explicit, or that can't be resolved against `/Dests`,
+ * are left untouched.
+ *
+ * @param {import('pdf-lib').PDFDocument} pdfDoc
+ * @returns {void}
+ */
+export function resolveLinkAnnotationDestinations(pdfDoc) {
+  const dests = getDests(pdfDoc)
+  if (!dests) {
+    return
+  }
+  const context = pdfDoc.context
+  for (const page of pdfDoc.getPages()) {
+    const annots = page.node.Annots()
+    if (!annots) {
+      continue
+    }
+    for (let i = 0; i < annots.size(); i++) {
+      const annot = context.lookup(annots.get(i))
+      if (!(annot instanceof PDFDict)) {
+        continue
+      }
+      if (annot.get(SubtypeName) !== LinkName) {
+        continue
+      }
+      const destValue =
+        context.lookup(annot.get(DestName)) || annot.get(DestName)
+      if (!(destValue instanceof PDFName)) {
+        continue
+      }
+      const resolved = resolveNamedDestination(dests, context, destValue)
+      if (resolved) {
+        annot.set(DestName, resolved)
+      }
+    }
+  }
+}
+
+/**
+ * Remove the document-level `/Dests` name dictionary - both the catalog
+ * entry and, when it's stored as an indirect object, the underlying object
+ * itself. Leaving the indirect object in place (even unreferenced) still
+ * gets it written out on save, oversized name keys and all: `PDFDocument.save()`
+ * serializes every object it knows about regardless of whether anything
+ * still points to it, which was still tripping strict PDF parsers even
+ * after every reference had been resolved to an explicit destination.
+ *
+ * Only call this after every named-destination reference has been resolved
+ * (see `resolveLinkAnnotationDestinations` and `addOutline` in
+ * `outline.js`) - removing it first would break any reference still using a
+ * `PDFName`.
+ *
+ * @param {import('pdf-lib').PDFDocument} pdfDoc
+ * @returns {void}
+ */
+export function removeNamedDestinations(pdfDoc) {
+  const destsEntry = pdfDoc.catalog.get(DestsName)
+  pdfDoc.catalog.delete(DestsName)
+  if (destsEntry instanceof PDFRef) {
+    pdfDoc.context.delete(destsEntry)
+  }
+}
+
+/**
+ * Run the full named-destination cleanup: resolve every in-page link
+ * annotation's named `/Dest` to an explicit destination, then drop the
+ * `/Dests` name dictionary. Must run after `addOutline`, which resolves the
+ * outline (bookmark) entries' own named destinations.
+ *
+ * @param {import('pdf-lib').PDFDocument} pdfDoc
+ * @returns {import('pdf-lib').PDFDocument}
+ */
+export function sanitizeNamedDestinations(pdfDoc) {
+  resolveLinkAnnotationDestinations(pdfDoc)
+  removeNamedDestinations(pdfDoc)
+  return pdfDoc
+}

--- a/test/docker-smoke-test.md5sum
+++ b/test/docker-smoke-test.md5sum
@@ -1,1 +1,1 @@
-0cd840c1cbd00946ba149453b547ac37  test/output/docker-smoke-test.pdf
+08e545672fdcd187046ce82c264ae80c  test/output/docker-smoke-test.pdf

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -650,6 +650,47 @@ describe('PDF converter', () => {
         `expected no "Unable to find destination" warning, got: ${messages.join('; ')}`,
       )
     })
+
+    // Vivliostyle's named destinations encode the full source document URL
+    // (viv-id-<encoded-url>#<id>), which routinely exceeds the PDF spec's
+    // 127-byte limit for name tokens and trips up strict PDF parsers with
+    // "Warning: name token is longer than what the specification says it
+    // can be". Both the outline entries and the in-page cross-reference
+    // links must be resolved to explicit destinations, and the oversized
+    // `/Dests` dictionary itself must be dropped from the output.
+    it('should not leave any named destination in the generated PDF', async () => {
+      const pdfDoc = await convert(
+        fixturesPath('anchor-with-diacritics.adoc'),
+        outputPath('anchor-with-diacritics-dests.pdf'),
+      )
+      assert.strictEqual(
+        pdfDoc.catalog.get(PDFName.of('Dests')),
+        undefined,
+        'expected the /Dests name dictionary to be removed from the catalog',
+      )
+      const namedLinkDests = []
+      for (const page of pdfDoc.getPages()) {
+        const annots = page.node.Annots()
+        if (!annots) {
+          continue
+        }
+        for (let i = 0; i < annots.size(); i++) {
+          const annot = pdfDoc.context.lookup(annots.get(i))
+          if (annot.get(PDFName.of('Subtype')) !== PDFName.of('Link')) {
+            continue
+          }
+          const dest = annot.get(PDFName.of('Dest'))
+          if (dest instanceof PDFName) {
+            namedLinkDests.push(dest.asString())
+          }
+        }
+      }
+      assert.deepStrictEqual(
+        namedLinkDests,
+        [],
+        'expected every link annotation to use an explicit destination, not a named one',
+      )
+    })
   })
 
   describe('Known issues (bucket D backlog triage)', () => {


### PR DESCRIPTION
Vivliostyle encodes named destinations as `viv-id-<full-source-document-URL>#<id>`, with every non-alphanumeric character of the URL hex-escaped. Since the source URL is a `file://` path, this routinely produces PDF name tokens several hundred bytes long — well past the PDF spec's 127-byte limit for name objects (ISO 32000-1, §7.3.5), which trips up strict PDF parsers with warnings like `Warning: name token is longer than what the specification says it can be`.

`lib/outline.js` already resolved this for PDF outline (bookmark) entries by looking them up against the document's `/Dests` name dictionary and substituting the explicit destination. This change extends the same resolution to in-page link annotations (TOC links, cross-references), via a new dedicated `lib/pdf-destinations.js` module, and then removes the `/Dests` dictionary itself — including its underlying indirect object, which `pdf-lib` otherwise keeps serializing on save even once nothing references it, which was still triggering the warning on its own.
