### PR TITLE
feat: set CLI program name to asciidoctor-web-pdf in --help usage line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded `asciidoctor` to 4.0.11; the `--help` usage line now shows `asciidoctor-web-pdf` instead of `asciidoctor` as the program name
+
 ### Fixed
 
 - `:stem:` expressions needing an on-demand-loaded font variant (e.g. `\mathscr`) no longer fail on Windows with `Only URLs with a scheme in: file, data, and node are supported by the default ESM loader`; MathJax's separate on-demand loader used for these variants was still using the default ESM `import()`-based loader, missed by the earlier fix for the same error

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -70,6 +70,10 @@ export class PdfOptions extends Options {
     })
   }
 
+  getProgramName() {
+    return 'asciidoctor-web-pdf'
+  }
+
   _buildConvertOptions(extraAttrs = []) {
     const built = super._buildConvertOptions([
       'converter=web-pdf',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/free-solid-svg-icons": "6.2.1",
         "@puppeteer/browsers": "~3.0",
         "@vivliostyle/viewer": "2.44.1",
-        "asciidoctor": ">= 4.0.0 < 5",
+        "asciidoctor": ">= 4.0.11 < 5",
         "chokidar": "~3.5",
         "fs-extra": "~11.1.0",
         "highlight.js": "^11.11.1",
@@ -45,7 +45,7 @@
         "npm": ">=8.0.0"
       },
       "peerDependencies": {
-        "asciidoctor": ">= 4.0.0 < 5"
+        "asciidoctor": ">= 4.0.11 < 5"
       }
     },
     "node_modules/@antora/asciidoc-loader": {
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@asciidoctor/core": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.8.tgz",
-      "integrity": "sha512-Yg/ILwZbjoBIhdQV4PZ5VtCnfn+DQgdt6iBI4wqpZv3y8e7d2tU663os9RsQmaTxSa6XyitASpUn4JxG6PYtFg==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.11.tgz",
+      "integrity": "sha512-5uWPTLTiPJVQp9q4MllSROM2avdECzoT7oeVw/onT9H2PIdCCtQwKrSTvztwxMbSu/8cqHqZox/2qTBrQN454g==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -1323,12 +1323,12 @@
       "dev": true
     },
     "node_modules/asciidoctor": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.8.tgz",
-      "integrity": "sha512-ODLgL1kQpCGuw4So3EDgdCMqnKXL6BkqW1MAFIFNTFi6IMDL+1LqXW/im3OY+fqeTY6buu2UL93x1MXrpNndjw==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.11.tgz",
+      "integrity": "sha512-8KiLQVN1RmDfN2n4qWlysWorelAWZFLgtQcbTd6NJVeKRXCgtrxDEICGJqVSy9zOLVDjcnpdhM7Swjf/i4LHCA==",
       "license": "MIT",
       "dependencies": {
-        "@asciidoctor/core": "4.0.8"
+        "@asciidoctor/core": "4.0.11"
       },
       "bin": {
         "asciidoctor": "bin/asciidoctor",
@@ -4173,9 +4173,9 @@
       }
     },
     "@asciidoctor/core": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.8.tgz",
-      "integrity": "sha512-Yg/ILwZbjoBIhdQV4PZ5VtCnfn+DQgdt6iBI4wqpZv3y8e7d2tU663os9RsQmaTxSa6XyitASpUn4JxG6PYtFg=="
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.11.tgz",
+      "integrity": "sha512-5uWPTLTiPJVQp9q4MllSROM2avdECzoT7oeVw/onT9H2PIdCCtQwKrSTvztwxMbSu/8cqHqZox/2qTBrQN454g=="
     },
     "@bestikk/changelog": {
       "version": "1.0.0",
@@ -4655,11 +4655,11 @@
       "dev": true
     },
     "asciidoctor": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.8.tgz",
-      "integrity": "sha512-ODLgL1kQpCGuw4So3EDgdCMqnKXL6BkqW1MAFIFNTFi6IMDL+1LqXW/im3OY+fqeTY6buu2UL93x1MXrpNndjw==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.11.tgz",
+      "integrity": "sha512-8KiLQVN1RmDfN2n4qWlysWorelAWZFLgtQcbTd6NJVeKRXCgtrxDEICGJqVSy9zOLVDjcnpdhM7Swjf/i4LHCA==",
       "requires": {
-        "@asciidoctor/core": "4.0.8"
+        "@asciidoctor/core": "4.0.11"
       }
     },
     "asciidoctor-opal-runtime": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@fortawesome/free-solid-svg-icons": "6.2.1",
     "@puppeteer/browsers": "~3.0",
     "@vivliostyle/viewer": "2.44.1",
-    "asciidoctor": ">= 4.0.0 < 5",
+    "asciidoctor": ">= 4.0.11 < 5",
     "chokidar": "~3.5",
     "fs-extra": "~11.1.0",
     "highlight.js": "^11.11.1",
@@ -70,6 +70,6 @@
     "postject": "1.0.0-alpha.6"
   },
   "peerDependencies": {
-    "asciidoctor": ">= 4.0.0 < 5"
+    "asciidoctor": ">= 4.0.11 < 5"
   }
 }


### PR DESCRIPTION
Upgrades asciidoctor to 4.0.11, which adds Options#getProgramName() for customizing the usage line. PdfOptions now overrides it so `--help` shows `asciidoctor-web-pdf` instead of the inherited `asciidoctor`.