### PR TITLE
fix: use CJS require for MathJax's on-demand font variant loader on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `:stem:` expressions needing an on-demand-loaded font variant (e.g. `\mathscr`) no longer fail on Windows with `Only URLs with a scheme in: file, data, and node are supported by the default ESM loader`; MathJax's separate on-demand loader used for these variants was still using the default ESM `import()`-based loader, missed by the earlier fix for the same error
+
 ## [1.0.2] - 2026-08-19
 
 ### Fixed

--- a/examples/document/basic-example.adoc
+++ b/examples/document/basic-example.adoc
@@ -47,6 +47,8 @@ sqrt(4) = 2
 Water (stem:[H_2O]) is a critical component.
 
 latexmath:[C = \alpha + \beta Y^{\gamma} + \epsilon]
+
+latexmath:[\mathscr{C}]
 --
 
 <<<

--- a/lib/document/stem.js
+++ b/lib/document/stem.js
@@ -69,6 +69,28 @@ async function getMathJax(tags) {
     // anyway, since SEA binaries run in CJS-only mode where import() of external
     // files does not work).
     MathJaxModule.config.loader.require = require
+    // output/chtml's on-demand loading of per-variant glyph files (e.g. the
+    // "script" variant needed for \mathscr) goes through a *different*
+    // loader: MathJax._.mathjax.mathjax.asyncLoad. node-main.js sets that up
+    // once, at module-load time (i.e. when `import 'mathjax'` above runs),
+    // using a closure over whatever config.loader.require was *at that
+    // moment* -- the default, ESM-import-based one, captured before the
+    // override just above ever executes. Reassigning config.loader.require
+    // does not reach that closure, so this on-demand loader keeps calling
+    // import() and fails on Windows with the same drive-letter URL error the
+    // comment above describes. Replace it directly, keeping its path
+    // resolution (bracketed "[pkg]/..." paths via Package.resolvePath, dot-
+    // relative paths resolved against the mathjax package root, anything
+    // else -- e.g. "node:worker_threads" for SVG output -- passed straight
+    // through) but backed by our CJS require instead of the broken closure.
+    const { Package } = MathJaxModule._.components.package
+    const mathjaxRoot = MathJaxModule.config.loader.paths.mathjax
+    MathJaxModule._.mathjax.mathjax.asyncLoad = (file) => {
+      if (file.charAt(0) === '[') return require(Package.resolvePath(file))
+      if (file.charAt(0) === '.')
+        return require(ospath.resolve(mathjaxRoot, file))
+      return require(file)
+    }
     instances.set(
       tags,
       MathJaxModule.init({


### PR DESCRIPTION
`output/chtml`'s on-demand loading of per-variant glyph files (e.g. the "script" variant needed for `\mathscr`) goes through a separate loader, `MathJax._.mathjax.mathjax.asyncLoad`, set up once at module-load time using a closure over the default ESM `import()`-based `loader.require` — captured before stem.js's existing override of `config.loader.require` ever runs, so it kept using `import()` and failed on Windows with "Only URLs with a scheme in: file, data, and node are supported".

Also adds `\mathscr` to `examples/document/basic-example.adoc`, which the Windows build's smoke test converts, so this class of regression is caught by CI going forward (the existing unit test for this case runs on macOS/Linux, where `import()` works fine even with the broken closure).
